### PR TITLE
Fix: Prevent negative radius in AnimatedBackground

### DIFF
--- a/src/components/AnimatedBackground.tsx
+++ b/src/components/AnimatedBackground.tsx
@@ -67,14 +67,14 @@ const AnimatedBackground: React.FC = () => {
         if (particle.y > canvas.height / 2) particle.y = -canvas.height / 2;
         if (particle.y < -canvas.height / 2) particle.y = canvas.height / 2;
         if (particle.z > 1000) particle.z = -1000;
-        if (particle.z < -1000) particle.z = 1000;
+        if (particle.z <= -1000) particle.z = 1000;
 
         // Draw particle
         ctx.save();
         ctx.globalAlpha = particle.opacity * scale;
         ctx.fillStyle = particle.color;
         ctx.beginPath();
-        ctx.arc(x2d, y2d, particle.size * scale, 0, Math.PI * 2);
+        ctx.arc(x2d, y2d, Math.max(0, particle.size * scale), 0, Math.PI * 2);
         ctx.fill();
         ctx.restore();
 


### PR DESCRIPTION
The `IndexSizeError` was caused by a negative radius being passed to `ctx.arc()` in `src/components/AnimatedBackground.tsx`.

This commit addresses the issue in two ways:

1.  Modified the z-coordinate wrapping logic to prevent `particle.z` from reaching values that would cause the `scale` factor to become zero or negative (e.g. `particle.z = -1000`). This was done by changing `particle.z < -1000` to `particle.z <= -1000`.
2.  Ensured the radius argument in `ctx.arc()` is always non-negative by wrapping `particle.size * scale` with `Math.max(0, ...)`. This acts as a safeguard against potential floating-point inaccuracies or other edge cases that might still lead to a negative scale factor.